### PR TITLE
Add new allocator: Datacap for clients who are paying to store data with storage providers supported by web3mine's Ramo Network

### DIFF
--- a/Allocators/recZhErX5XiDb9jH9.json
+++ b/Allocators/recZhErX5XiDb9jH9.json
@@ -1,0 +1,38 @@
+{
+  "address": "f1xmitblrmxo6ubt2jyokg4flfiruqkaag2oe3gca",
+  "name": "Datacap for clients who are paying to store data with storage providers supported by web3mine's Ramo Network",
+  "organization": "web3mine AG",
+  "pathway_addresses": {},
+  "associated_org_addresses": "f1xmitblrmxo6ubt2jyokg4flfiruqkaag2oe3gca",
+  "application": {
+    "audit": [
+      "Enterprise Data "
+    ],
+    "distribution": [],
+    "tranche_schedule": "I will use a custom calculation. ",
+    "required_sps": "1",
+    "required_replicas": "7",
+    "github_handles": [
+      "vvkio"
+    ],
+    "allocation_bookkeeping": "https://github.com/filplus-bookkeeping/web3mine-AG",
+    "client_contract_address": ""
+  },
+  "history": {
+    "Application Submitted": "",
+    "KYC Submitted": "",
+    "Approved": "",
+    "Declined": "",
+    "DC Allocated": ""
+  },
+  "audits": [
+    {
+      "started": "2025-07-16T12:48:50.000Z",
+      "ended": "",
+      "dc_allocated": "",
+      "outcome": "PENDING",
+      "datacap_amount": 5
+    }
+  ],
+  "old_allocator_id": ""
+}

--- a/Allocators/recZhErX5XiDb9jH9.json
+++ b/Allocators/recZhErX5XiDb9jH9.json
@@ -1,4 +1,5 @@
 {
+  "application_number": 418,
   "address": "f1xmitblrmxo6ubt2jyokg4flfiruqkaag2oe3gca",
   "name": "Datacap for clients who are paying to store data with storage providers supported by web3mine's Ramo Network",
   "organization": "web3mine AG",
@@ -19,7 +20,7 @@
     "client_contract_address": ""
   },
   "history": {
-    "Application Submitted": "",
+    "Application Submitted": "2025-07-16T12:49:04.000Z",
     "KYC Submitted": "",
     "Approved": "",
     "Declined": "",


### PR DESCRIPTION
# Filecoin Plus Allocator Application

## Application Details
| Field | Value |
|-------|-------|
| Applicant | Datacap for clients who are paying to store data with storage providers supported by web3mine's Ramo Network |
| Organization | web3mine AG |
| Address | [f1xmitblrmxo6ubt2jyokg4flfiruqkaag2oe3gca](https://filfox.info/en/address/f1xmitblrmxo6ubt2jyokg4flfiruqkaag2oe3gca) |
| GitHub Username | [![GitHub](https://img.shields.io/badge/GitHub-vvkio?style=flat-square&logo=github)](https://github.com/vvkio) |

## Grant Details
| Field | Value |
|-------|-------|
| DataCap Amount | 5 PiB |
| Allocation Method | RKH_ALLOCATOR |

---
<sup>This message was automatically generated by the Filecoin Plus Bot. For more information, visit [filecoin.io](https://filecoin.io)</sup>